### PR TITLE
Prices in the banner ad still appear

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Dominik Schlipper
+Copyright (c) 2020 Dominik Schlipper, Hans Liegener
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hide-euro-prices.user.js
+++ b/hide-euro-prices.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        hide-euro-prices
-// @version     1.2
-// @author      DoomDesign
+// @version     1.2.1
+// @author      DoomDesign, HAL2000
 // @include     http*://*amazon*/*
 // @description Hides (hopefully) all price elements on amazon
 // @run-at      document-start

--- a/hide-euro-prices.user.js
+++ b/hide-euro-prices.user.js
@@ -75,6 +75,15 @@
         attributeOldValue: false,
         characterDataOldValue: false
     });
+    
+    /* i couldn't fix this any other way though..... :( */
+    /* Any way I tried to implement this in the MutationObserver failed.  Even things like elm.ownerDocument.getElementById("priceAndPrime") didn't return anything?!? */
+    var pap = document.getElementById ("priceAndPrime");
+    if (pap)
+    {
+        pap.classList.add('hiddenByScript');
+        priceElems.push(pap);
+    }
 
     // create toggle button
     document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
This is an IMHO very dirty hotfix to solve the problem.

I tried the same fix like for `hero-quick-promo`, but I didn't seem to work for me.

Maybe I will look into a more stable way to implement this in the next couple days/weeks.

Tested on current Chrome on Win 10. Note for testing: You have to reload the page a few times. Each time, there seems to be a chance for the top banner to contain some add for a different product. Around Black Friday (as of today), its just a general ad for black friday dales most of the time annoyingly.