### PR TITLE
Block all iframes to prevent sponsored articles or promotions

### DIFF
--- a/hide-euro-prices.user.js
+++ b/hide-euro-prices.user.js
@@ -57,10 +57,8 @@
                                         priceElems.push(value);
                                 });
 
-                                // NEW: hide the quick promo iframe completely and don't add it to the revealable elements
-                                elm.querySelectorAll("[id*='hero-quick-promo']").forEach(function(value) {
-                                    value.classList.add('hiddenByScript');
-                                });
+                                // finally keep blocking all iframes to prevent sponsored articles or promotions for related products
+                                document.querySelectorAll('iframe').forEach(iframe => iframe.remove());
                             };
                         }
                     });


### PR DESCRIPTION
Amazon seems to keep adding iframes to their product pages for sponsored articles or promotions. These are often injected via JS after the DOM has finished loading.

This pull request changes the behavior of blocking specific iframes by ID to a generic iframe blocker.