### PR TITLE
fix minor race condition

### DIFF
--- a/hide-euro-prices.user.js
+++ b/hide-euro-prices.user.js
@@ -11,62 +11,81 @@
 (function() {
     'use strict';
 
-    var textToSearch = '(EUR|€)';
+    var regTextToSearch = /(EUR|€)/;
     var priceElems = [];
-    var timeout;
     var pricesHidden = true;
 
     // see https://stackoverflow.com/a/10730777
     function textNodesUnder(el){
-        var n, a=[], walk=document.createTreeWalker(el,NodeFilter.SHOW_TEXT,null,false);
+        var n, a=[], walk=document.createTreeWalker(el,NodeFilter.SHOW_TEXT);
         while(n=walk.nextNode()) a.push(n);
         return a;
     }
 
     // insert CSS
-    (document.head || document.documentElement).insertAdjacentHTML('beforeend',
-    "<style type='text/css'> button.showPrices {line-height: 1; padding: 10px; position: fixed; bottom: 1rem; right: 1rem; z-index: 9999; color: #000; background-color: #fff; font-size: 1.5rem; border: 1px solid red; border-radius: 5px;} button.showPrices:active, button.showPrices.active {background-color: red; color: #fff;} button.showPrices > small { display: block;} .hiddenByScript.visibleByScript {visibility: initial !important} .hiddenByScript.visibleByScript::after { opacity: 0; } .hiddenByScript {position: relative;} .hiddenByScript {visibility: hidden !important} /*.hiddenByScript::after {content: '???'; visibility: visible; font-weight: bold; font-family: 'Amazon Ember', Arial, sans-serif; color: #fff; opacity: 1; display: block; position: absolute; top: 0; right: 0; bottom: 0; left: 0; background-color: #000; overflow: hidden; text-align: center;}*/ </style>");
+    var cssString =
+        `<style type='text/css'>
+            button.showPrices {
+                line-height: 1;
+                padding: 10px;
+                position: fixed;
+                bottom: 1rem; right: 1rem;
+                z-index: 9999; color: #000;
+                background-color: #fff;
+                font-size: 1.5rem;
+                border: 1px solid red;
+                border-radius: 5px;
+            }
+            button.showPrices:active, button.showPrices.active {
+                background-color:
+                red; color: #fff;
+            }
+            button.showPrices > small { display: block; }
+
+            .hiddenByScript.visibleByScript { visibility: initial !important }
+            .hiddenByScript.visibleByScript::after { opacity: 0; }
+            .hiddenByScript {position: relative;}
+            .hiddenByScript {visibility: hidden !important}
+            /*.hiddenByScript::after {content: '???'; visibility: visible; font-weight: bold; font-family: 'Amazon Ember', Arial, sans-serif; color: #fff; opacity: 1; display: block; position: absolute; top: 0; right: 0; bottom: 0; left: 0; background-color: #000; overflow: hidden; text-align: center;}*/
+        </style>`;
 
     // mutation observer to directly add classes to elements with "price" in class names on page load
     new MutationObserver(function(mutations) {
-
         mutations.forEach(function(mutation) {
-
             if ( mutation.type == 'childList' ) {
                 if (mutation.addedNodes.length >= 1) {
                     mutation.addedNodes.forEach(function(elm) {
-                        if (elm.nodeName != '#text') {
-
-
-                            if(typeof elm.querySelectorAll === "function") {
-
-                                //find all nodes that contain a certain text
-                                // find all text nodes in elm
-                                var textnodes = textNodesUnder(elm);
-                                // iterate over text node
-                                textnodes.forEach(function(value){
-                                    if(value.nodeType === Node.TEXT_NODE && RegExp(textToSearch).test(value.textContent)) {
-                                        /* get parent element of textNode */
-                                        var parent = value.parentNode;
-                                        parent.classList.add('hiddenByScript');
-                                        priceElems.push(parent);
-                                    }
-                                });
-
-                                // additionally find all nodes with a specific class
-                                var classnodes = elm.querySelectorAll("[class*='price'], [class*='prices'], [class*='Price']");
-                                classnodes.forEach(function(value){
-                                        value.classList.add('hiddenByScript');
-                                        priceElems.push(value);
-                                });
-
-                                // NEW: hide promo iframe and placement elements completely and don't add it to the revealable elements
-                                document.querySelectorAll("[id*='hero-quick-promo']:not(.hiddenByScript), [data-cel-widget*='placement']:not(.hiddenByScript), [data-ad-details]:not(.hiddenByScript)").forEach(function(value) {
-                                    value.classList.add('hiddenByScript');
-                                    value.style.display = 'none';
-                                });
-                            };
+                        if (elm.nodeName === '#text' || !elm.querySelectorAll) {
+                            return;
                         }
+
+                        //find all nodes that contain a certain text
+                        // find all text nodes in elm
+                        var textnodes = textNodesUnder(elm);
+                        // iterate over text node
+                        textnodes.forEach(function(value){
+                            if(value.nodeType === Node.TEXT_NODE && regTextToSearch.test(value.textContent)) {
+                                /* get parent element of textNode */
+                                var parent = value.parentNode;
+                                parent.classList.add('hiddenByScript');
+                                parent.style.visibility = "hidden";
+                                priceElems.push(parent);
+                            }
+                        });
+
+                        // additionally find all nodes with a specific class
+                        var classnodes = elm.querySelectorAll("[class*='price'], [class*='prices'], [class*='Price']");
+                        classnodes.forEach(function(value){
+                                value.classList.add('hiddenByScript');
+                                value.style.visibility = "hidden";
+                                priceElems.push(value);
+                        });
+
+                        // NEW: hide promo iframe and placement elements completely and don't add it to the revealable elements
+                        document.querySelectorAll("[id*='hero-quick-promo']:not(.hiddenByScript), [data-cel-widget*='placement']:not(.hiddenByScript), [data-ad-details]:not(.hiddenByScript)").forEach(function(value) {
+                            value.classList.add('hiddenByScript');
+                            value.style.display = 'none';
+                        });
                     });
                 }
             }
@@ -83,30 +102,25 @@
     // create toggle button
     document.addEventListener("DOMContentLoaded", function() {
         var button = document.createElement("button");
-        button.innerHTML = "Preise anzeigen/ausblenden";
+        document.head.insertAdjacentHTML('beforeend',cssString);
+
+        button.textContent = "Preise anzeigen";
         button.classList.add('showPrices');
         button.onclick = function(){
-            clearInterval(timeout);
             if(pricesHidden === true) {
-                console.log("Showing...");
-                pricesHidden = false;
-                button.classList.add('active');
-                timeout = setInterval(function() {
+                priceElems.forEach(function(elm) {
+                    elm.classList.add('visibleByScript');
+                });
 
-                    priceElems.forEach(function(elm) {
-                        elm.classList.add('visibleByScript');
-                    });
-                }, 500);
-
-                return false;
             } else {
-                console.log("Hiding...");
-                pricesHidden = true;
-                button.classList.remove('active');
                 priceElems.forEach(function(elm) {
                     elm.classList.remove('visibleByScript');
                 });
             }
+
+            button.textContent = ["Preise anzeigen", "Preise ausblenden"][+pricesHidden];
+            pricesHidden = !pricesHidden;
+            button.classList.toggle('active');
         }
         document.body.appendChild(button);
     });


### PR DESCRIPTION
Hi!

Ein anderer der Pull requests war korrekt, da es wirklich zu einer race condition kommen kann.
Ich fand es merkwürdig, dass man "document.head || document.documentElement" machen muss.
Wenn man ausreichend viele Tabs öffnet, ist auch manchmal das documentElement nicht defined.
Das Problem ist eben, dass man dann die CSS Klassen nicht adden kann. Als Workaround
setzen wir die Visibility inline auf hidden und deine Klassen machen dank dem !important dann den Rest.
Das ist eigentlich die einzig tragende Änderung, der Rest ist nur ein bisschen Kosmetik.
Falls du den Rest, also außer dem cssString nicht brauchst, dann ist dein Timeout zumindest ein Interval.
Ich hab es ganz weg gemacht, weil ich das von Usability etwas fragwürdig fand, dass ein Knopf erst eine
halbe Sekunde später regiert, Wenn das aber Kunst ist und nicht weg kann, besser setTimeout verwenden.

Peace, love & happiness